### PR TITLE
basic fen support for new game

### DIFF
--- a/app/components/game.hbs
+++ b/app/components/game.hbs
@@ -14,8 +14,11 @@
   {{if this.isShowingKey "show-key"}}
   {{if this.isRotate "rotate"}}
   {{if this.isShowingGuide "show-guide"}}
-  {{if this.isShowingLog "show-log"}}
-">
+  {{if this.isShowingLog "show-log"}}"
+  data-test="game"
+  data-turn="{{this.turn}}"
+  data-turn-color="{{this.turnColor}}"
+>
   <Board
     @board={{this.board}}
     @turnColor={{this.turnColor}}
@@ -33,4 +36,6 @@
   @toggleGuide={{this.toggleGuide}}
   @isShowingLog={{this.isShowingLog}}
   @toggleLog={{this.toggleLog}}
+  @fen={{this.fen}}
+  @updateFen={{this.updateFen}}
 />

--- a/app/components/game.js
+++ b/app/components/game.js
@@ -2,27 +2,35 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import Board from 'ember-chess/lib/board';
+import Fen from 'ember-chess/lib/fen';
 
 export default class GameComponent extends Component {
   @tracked board = new Board();
 
   @tracked turn = 1;
+  @tracked turnColor = 'white';
   @tracked isShowingGuide = false;
   @tracked isShowingKey = false;
   @tracked isShowingLog = false;
   @tracked isRotate = false;
   @tracked previousTurnInfo = null;
-
-  get turnColor() {
-    return this.turn % 2 ? 'white' : 'black';
-  }
+  @tracked fen = null;
 
   @action resetGame() {
-    this.board = new Board();
+    let fen = new Fen(this.fen);
+    this.board = new Board(fen);
+    this.turn = fen.isValid ? fen.fullTurnCount : 1;
+    this.turnColor = fen.isValid ? fen.turnColor : 'white';
+    this.fen = null;
   }
 
   @action incrementTurn(turn) {
-    this.turn++;
+    if (this.turnColor === 'black') {
+      this.turn++;
+      this.turnColor = 'white';
+    } else {
+      this.turnColor = 'black';
+    }
     this.previousTurnInfo = turn;
   }
   @action toggleGuide() {
@@ -36,5 +44,8 @@ export default class GameComponent extends Component {
   }
   @action toggleRotate() {
     this.isRotate = !this.isRotate;
+  }
+  @action updateFen(event) {
+    this.fen = event.target.value;
   }
 }

--- a/app/components/settings.hbs
+++ b/app/components/settings.hbs
@@ -14,17 +14,48 @@
     <form class="settings-modal" action={{this.toggle}}>
       <fieldset>
         <legend class="sr-only">Game settings</legend>
-        <label title="displays grid coordinates (ex. a1, b2)"><input type="checkbox" checked={{@isShowingKey}} {{on "change" @toggleKey}}> Show key</label>
-        <label title="Highlights available spaces when a piece is selected"><input type="checkbox" checked={{@isShowingGuide}} {{on "change" @toggleGuide}}> Show move guide</label>
-        <label title="Current player is always at the bottom of the board"><input type="checkbox" checked={{@isRotate}} {{on "change" @toggleRotate}}> Rotate board every turn</label>
-        <label title="coming soon"><input type="checkbox" checked={{@isShowingLog}} {{on "change" @toggleLog}} disabled> Show game log</label>
+
+        <label title="displays grid coordinates (ex. a1, b2)">
+          <input type="checkbox" checked={{@isShowingKey}} {{on "change" @toggleKey}}>
+          Show key
+        </label>
+
+        <label title="Highlights available spaces when a piece is selected">
+          <input type="checkbox" checked={{@isShowingGuide}} {{on "change" @toggleGuide}}>
+          Show move guide
+        </label>
+
+        <label title="Current player is always at the bottom of the board">
+          <input type="checkbox" checked={{@isRotate}} {{on "change" @toggleRotate}}>
+          Rotate board every turn
+        </label>
+
+        <label title="coming soon">
+          <input type="checkbox" checked={{@isShowingLog}} {{on "change" @toggleLog}} disabled>
+          Show game log
+        </label>
+
+        <textarea
+          aria-label="FEN code for new game (optional)"
+          autocomplete="off"
+          autocorrect="off"
+          autocapitalize="off"
+          class="fen-textarea"
+          data-test="fen-textarea"
+          spellcheck="false"
+          placeholder="FEN for new game (optional)"
+          value={{@fen}}
+          {{on "input" @updateFen}}
+        >
+        </textarea>
 
         <button
           type="button"
           class="new-game"
+          data-test="new-game-button"
           {{on "click" @resetGame}}
         >
-          new game
+          start new game
         </button>
       </fieldset>
     </form>

--- a/app/lib/board.js
+++ b/app/lib/board.js
@@ -7,6 +7,7 @@ import {
   Queen,
   King,
 } from 'ember-chess/lib/pieces';
+import Fen from 'ember-chess/lib/fen';
 
 const letterToIndex = (string) => string.charCodeAt(0) - 97;
 //const indexToLetter = (number) => String.fromCharCode(97 + number);
@@ -37,50 +38,28 @@ export default class Board {
     return this.#grid;
   }
 
-  constructor() {
-    this.setupBoard();
+  constructor(fen) {
+    this.setupBoard(fen);
   }
 
-  setupBoard() {
-    let color = 'white';
-    this.createPiece(Rook, { position: 'a1', color });
-    this.createPiece(Knight, { position: 'b1', color });
-    this.createPiece(Bishop, { position: 'c1', color });
-    this.createPiece(Queen, { position: 'd1', color });
-    this.createPiece(King, { position: 'e1', color });
-    this.createPiece(Bishop, { position: 'f1', color });
-    this.createPiece(Knight, { position: 'g1', color });
-    this.createPiece(Rook, { position: 'h1', color });
-    this.createPiece(Pawn, { position: 'a2', color });
-    this.createPiece(Pawn, { position: 'b2', color });
-    this.createPiece(Pawn, { position: 'c2', color });
-    this.createPiece(Pawn, { position: 'd2', color });
-    this.createPiece(Pawn, { position: 'e2', color });
-    this.createPiece(Pawn, { position: 'f2', color });
-    this.createPiece(Pawn, { position: 'g2', color });
-    this.createPiece(Pawn, { position: 'h2', color });
-
-    color = 'black';
-    this.createPiece(Rook, { position: 'a8', color });
-    this.createPiece(Knight, { position: 'b8', color });
-    this.createPiece(Bishop, { position: 'c8', color });
-    this.createPiece(Queen, { position: 'd8', color });
-    this.createPiece(King, { position: 'e8', color });
-    this.createPiece(Bishop, { position: 'f8', color });
-    this.createPiece(Knight, { position: 'g8', color });
-    this.createPiece(Rook, { position: 'h8', color });
-    this.createPiece(Pawn, { position: 'a7', color });
-    this.createPiece(Pawn, { position: 'b7', color });
-    this.createPiece(Pawn, { position: 'c7', color });
-    this.createPiece(Pawn, { position: 'd7', color });
-    this.createPiece(Pawn, { position: 'e7', color });
-    this.createPiece(Pawn, { position: 'f7', color });
-    this.createPiece(Pawn, { position: 'g7', color });
-    this.createPiece(Pawn, { position: 'h7', color });
+  setupBoard(fen) {
+    if (!fen || !fen.isValid) {
+      fen = new Fen();
+    }
+    fen.pieces.forEach((piece) => this.createPiece(piece));
   }
 
-  createPiece(Piece, { position, color }) {
+  createPiece({ type, position, color }) {
     let { row, col } = positionToCoord(position);
+    let pieceClasses = {
+      pawn: Pawn,
+      rook: Rook,
+      knight: Knight,
+      bishop: Bishop,
+      queen: Queen,
+      king: King,
+    };
+    let Piece = pieceClasses[type];
 
     this.#grid[row][col] = new Piece({ position, color, board: this });
   }

--- a/app/lib/fen.js
+++ b/app/lib/fen.js
@@ -1,0 +1,123 @@
+// https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation
+const STARTING_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+
+class FenPiece {
+  #string;
+  #rank;
+  #file;
+  constructor(string, rank, file) {
+    this.#string = string;
+    this.#rank = rank;
+    this.#file = file;
+  }
+  get color() {
+    return this.#string === this.#string.toUpperCase() ? 'white' : 'black';
+  }
+  get type() {
+    let types = {
+      p: 'pawn',
+      r: 'rook',
+      n: 'knight',
+      b: 'bishop',
+      q: 'queen',
+      k: 'king',
+    };
+    return types[this.#string.toLowerCase()];
+  }
+  get position() {
+    return `${String.fromCharCode(97 + this.#file)}${this.#rank + 1}`;
+  }
+}
+
+export default class Fen {
+  constructor(fenString) {
+    this.fen = fenString || STARTING_FEN;
+  }
+
+  get isValid() {
+    let segments = this.fen.split(' ');
+    let [
+      board,
+      turnColor,
+      castling,
+      enPassant,
+      halfCount,
+      fullCount,
+    ] = segments;
+    let ranks = board.split('/');
+
+    let hasFenWith6SpaceDelimitedSegments = segments.length === 6;
+    let hasBoardWith8SlashDelimitedRanks = ranks.length === 8;
+    let hasRanksWith8Positions = ranks.every((rank) => {
+      let count = rank
+        .split('')
+        .map((value) => {
+          let int = parseInt(value, 10);
+          return isNaN(int) ? 1 : int;
+        })
+        .reduce((a, b) => a + b, 0);
+      return count === 8;
+    });
+
+    let hasValidTurnColor = ['w', 'b'].includes(turnColor);
+    let hasValidCastling =
+      castling === '-' ||
+      (castling.length <= 5 &&
+        castling.length > 1 &&
+        [...castling].every((char) => ['K', 'k', 'Q', 'q'].includes(char)));
+
+    let hasValidEnPassant = enPassant === '-' || enPassant.length === 2;
+    let hasValidHalfCount = !isNaN(parseInt(halfCount, 10)) && halfCount >= 0;
+    let hasValidFullCount = !isNaN(parseInt(fullCount, 10)) && fullCount > 0;
+
+    return (
+      hasFenWith6SpaceDelimitedSegments &&
+      hasBoardWith8SlashDelimitedRanks &&
+      hasRanksWith8Positions &&
+      hasValidTurnColor &&
+      hasValidCastling &&
+      hasValidEnPassant &&
+      hasValidHalfCount &&
+      hasValidFullCount
+    );
+  }
+
+  get pieces() {
+    let ranks = this.fen.split(' ')[0];
+    return ranks.split('/').reverse().map(this.rankToPieces).flat();
+  }
+
+  get turnColor() {
+    let color = this.fen.split(' ')[1];
+    return color === 'w' ? 'white' : 'black';
+  }
+
+  get halfTurnCount() {
+    return parseInt(this.fen.split(' ')[4], 10);
+  }
+
+  get fullTurnCount() {
+    return parseInt(this.fen.split(' ')[5], 10);
+  }
+
+  rankToPieces(rankString, rankIndex) {
+    let values = rankString.split('');
+
+    let fullRank = values
+      .map((value) => {
+        let maybeNumber = parseInt(value, 10);
+        return isNaN(maybeNumber) ? value : [...Array(maybeNumber)];
+      })
+      .flat();
+
+    let positions = fullRank.map((value, fileIndex) => {
+      if (value) {
+        return new FenPiece(value, rankIndex, fileIndex);
+      }
+    });
+
+    let pieces = positions.filter(Boolean);
+
+    return pieces;
+  }
+}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -212,6 +212,16 @@ th[scope="col"] {
   color: #6b7280;
 }
 
+.fen-textarea {
+  margin-top: 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: #f9fafb;
+  color: #6b7280;
+  resize: vertical;
+  width: 97%;
+}
+
 .new-game {
   border: 1px solid #d1d5db;
   border-radius: 4px;

--- a/tests/acceptance/game-test.js
+++ b/tests/acceptance/game-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { click, triggerEvent, visit } from '@ember/test-helpers';
+import { click, fillIn, triggerEvent, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
 module('Acceptance | game', function (hooks) {
@@ -68,24 +68,65 @@ module('Acceptance | game', function (hooks) {
     });
   });
 
-  test('Starting a new game', async function (assert) {
-    await visit('');
+  module('New Game', function () {
+    test('Starting a new game', async function (assert) {
+      await visit('');
 
-    assert
-      .dom(position('a3'))
-      .hasAttribute('data-test', 'empty-space', 'a3 is empty');
+      assert
+        .dom(position('a3'))
+        .hasAttribute('data-test', 'empty-space', 'a3 is empty');
 
-    await clickMove('a2', 'a3');
+      assert
+        .dom('[data-test="game"]')
+        .hasAttribute('data-turn-color', 'white', 'It is now white turn');
 
-    assert
-      .dom(position('a3'))
-      .hasAttribute('data-test', 'pawn', 'a3 is a pawn');
+      await clickMove('a2', 'a3');
 
-    await click('[data-test="settings-button"]');
-    await click('button.new-game');
+      assert
+        .dom(position('a3'))
+        .hasAttribute('data-test', 'pawn', 'a3 is a pawn');
 
-    assert
-      .dom(position('a3'))
-      .hasAttribute('data-test', 'empty-space', 'a3 is empty');
+      assert
+        .dom('[data-test="game"]')
+        .hasAttribute('data-turn-color', 'black', 'It is now black turn');
+
+      await click('[data-test="settings-button"]');
+      await click('[data-test="new-game-button"]');
+
+      assert
+        .dom(position('a3'))
+        .hasAttribute('data-test', 'empty-space', 'a3 is empty');
+
+      assert
+        .dom('[data-test="game"]')
+        .hasAttribute('data-turn-color', 'white', 'It is now white turn');
+    });
+
+    test('Starting a new game with a FEN', async function (assert) {
+      const fen =
+        'rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2';
+      await visit('');
+
+      await click('[data-test="settings-button"]');
+
+      await fillIn('[data-test="fen-textarea"]', fen);
+      await click('[data-test="new-game-button"]');
+
+      assert
+        .dom(position('e2'))
+        .hasAttribute('data-test', 'empty-space', 'e2 is empty');
+
+      assert
+        .dom(position('e4'))
+        .hasAttribute('data-test', 'pawn', 'e4 is a pawn');
+
+      assert
+        .dom('[data-test="game"]')
+        .hasAttribute('data-turn', '2', 'It is now turn 2');
+
+      assert
+        .dom('[data-test="game"]')
+        .hasAttribute('data-turn-color', 'black', 'It is now black turn');
+    });
   });
 });


### PR DESCRIPTION
Add basic support for start games based on a FEN string. 
Adds the ability to use a FEN string to start a new game, validates FEN, and falls back to default FEN for invalid strings.

Updates turn clock to count white+black move pair as a single turn to comply with FEN.

Closes #7 