### PR TITLE
Game rule: pawn promotion

### DIFF
--- a/app/components/side.hbs
+++ b/app/components/side.hbs
@@ -7,6 +7,7 @@
           @type={{piece.type}}
           @color={{piece.color}}
         />
+        <span class="sr-only">{{piece.color}} {{piece.type}}</span>
       </li>
     {{/each}}
   </ul>

--- a/app/lib/board.ts
+++ b/app/lib/board.ts
@@ -64,6 +64,9 @@ export default class Board {
 
   move(fromPosition: Position, toPosition: Position) {
     let piece = this.getPosition(fromPosition);
+
+    if (!piece) return;
+
     let destinationPiece = this.getPosition(toPosition);
 
     this.setPosition(fromPosition, _);
@@ -72,6 +75,17 @@ export default class Board {
     if (destinationPiece) {
       this.#capturedPieces.push(destinationPiece);
     }
+
+    if (this.isPawnPromotion(piece, toPosition)) {
+      this.createPiece({ type: 'queen', position: toPosition, color: piece.color });
+    }
+  }
+
+  isPawnPromotion(piece: PieceInstance, position: Position) {
+    if (piece?.type === 'pawn' && piece?.color === 'black' && position.endsWith('1')) return true;
+    if (piece?.type === 'pawn' && piece?.color === 'white' && position.endsWith('8')) return true;
+
+    return false;
   }
 
   isPositionOnBoard(position: Position) {

--- a/tests/acceptance/game-test.js
+++ b/tests/acceptance/game-test.js
@@ -140,4 +140,22 @@ module('Acceptance | game', function (hooks) {
       assertCaptured(assert, 'white pawn');
     });
   });
+
+  module('Pawn promotion', function () {
+    test('White pawn can be promoted to Queen', async function (assert) {
+      assert.expect(4);
+
+      await visit('');
+
+      await startNewGame('8/P7/8/8/8/8/8/8 w - - 0 1');
+
+      assertPosition(assert, 'a7', 'white pawn');
+      assertPosition(assert, 'a8', 'empty-space');
+
+      await clickMove('a7', 'a8');
+
+      assertPosition(assert, 'a7', 'empty-space');
+      assertPosition(assert, 'a8', 'white queen');
+    });
+  });
 });


### PR DESCRIPTION
Closes #20 

Introduces a simple mechanism for automatically promoting a pawn to a Queen.

Chess rules allow for promotion to Queen, rook, knight or bishop, but "down promotion" to any piece beside Queen is relatively rare and generally only useful to avoid stalemate, which this app doesn't even support yet.

Support for Down Promotion will require a new UI to suspend the turn and allow piece selection for the promotion.